### PR TITLE
Fix filtering by upstream in browser

### DIFF
--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -65,7 +65,7 @@ def get_packages(**kwargs):
                     if kwargs.get('tag') in package.get('tags')]
     if kwargs.get('upstream'):
         packages = [package for package in packages
-                    if kwargs.get('upstream') in package.get('upstream')]
+                    if kwargs.get('upstream') in str(package.get('upstream'))]
 
     return packages
 


### PR DESCRIPTION
We noticed there is a single project that has no upstream
repository defined and it causes failures in filtering.
Proposed fix is to cast None in such case to string
so we can filter for it anyway.