### PR TITLE
Add projects argument under browse-osp

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ To list URLs to repositories of packages that belong to network component:
 znoyder browse-osp packages --component network --tag osp-17.0 --output osp-patches
 ```
 
-There is a argument used to filter name projects. It will extract the information of the packages and get all the project names. We can filter in base of Git URL.
+There is a argument used in the output to filter project name:
 
 ```
-znoyder browse-osp projects
+znoyder browse-osp packages --output osp-project
 ```
 
 There exists the `--debug` option which will display raw dictionary as output.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ To list URLs to repositories of packages that belong to network component:
 znoyder browse-osp packages --component network --tag osp-17.0 --output osp-patches
 ```
 
+There is a argument used to filter name projects. It will extract the information of the packages and get all the project names. We can filter in base of Git URL.
+
+```
+znoyder browse-osp projects
+```
+
 There exists the `--debug` option which will display raw dictionary as output.
 It can be useful to find fields (key names) for `--output` option.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To list URLs to repositories of packages that belong to network component:
 znoyder browse-osp packages --component network --tag osp-17.0 --output osp-patches
 ```
 
-There is a argument used in the output to filter project name:
+There is an additional key `osp-project` introduced that contains downstream repository name:
 
 ```
 znoyder browse-osp packages --output osp-project

--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -94,7 +94,7 @@ def get_projects(**kwawrgs) -> list:
         # Filter for specific Git URL or all
         if kwawrgs.get('git_url') == git_hostname:
             projects.append({'name': project_name})
-        else:
+        elif not kwawrgs['git_url']:
             projects.append({'name': project_name})
     return projects
 

--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -68,6 +68,9 @@ def get_packages(**kwargs):
         packages = [package for package in packages
                     if kwargs.get('upstream') in str(package.get('upstream'))]
 
+    for package in packages:
+        package['osp-project'] = urlparse(package['osp-patches']).path[1:]
+
     return packages
 
 
@@ -93,23 +96,6 @@ def get_releases(**kwargs):
     return releases
 
 
-def get_projects(**kwawrgs) -> list:
-    packages = get_packages()
-    urls_components = [package['osp-patches'] for package in packages
-                       if package['osp-patches'] != '']
-    projects = []
-    for url_component in urls_components:
-        url_info = urlparse(url_component)
-        project_name = url_info.path[1:]
-        git_hostname = url_info.hostname
-        # Filter for specific Git URL or all
-        if kwawrgs.get('git') == git_hostname:
-            projects.append({'name': project_name})
-        elif not kwawrgs['git']:
-            projects.append({'name': project_name})
-    return projects
-
-
 def process_arguments(argv=None) -> Namespace:
     parser = ArgumentParser(description=APP_DESCRIPTION)
     subparsers = parser.add_subparsers(dest='command', metavar='command')
@@ -132,10 +118,6 @@ def process_arguments(argv=None) -> Namespace:
     packages.add_argument('--name', dest='name')
     packages.add_argument('--tag', dest='tag')
     packages.add_argument('--upstream', dest='upstream')
-
-    projects = subparsers.add_parser('projects', help='', parents=[common])
-    projects.add_argument('--git', dest='git', default=False,
-                          help='Git URL that contains projects')
 
     releases = subparsers.add_parser('releases', help='', parents=[common])
     releases.add_argument('--tag', dest='tag')
@@ -161,9 +143,6 @@ def main(argv=None) -> None:
     elif args.command == 'releases':
         results = get_releases(**vars(args))
         default_output = ['ospinfo_tag_name', 'git_release_branch']
-    elif args.command == 'projects':
-        results = get_projects(**vars(args))
-        default_output = ['name']
     else:
         results = None
 

--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -92,9 +92,9 @@ def get_projects(**kwawrgs) -> list:
         project_name = url_info.path[1:]
         git_hostname = url_info.hostname
         # Filter for specific Git URL or all
-        if kwawrgs.get('git_url') == git_hostname:
+        if kwawrgs.get('git') == git_hostname:
             projects.append({'name': project_name})
-        elif not kwawrgs['git_url']:
+        elif not kwawrgs['git']:
             projects.append({'name': project_name})
     return projects
 
@@ -123,7 +123,7 @@ def process_arguments(argv=None) -> Namespace:
     packages.add_argument('--upstream', dest='upstream')
 
     projects = subparsers.add_parser('projects', help='', parents=[common])
-    projects.add_argument('--git_url', dest='git_url', default=False,
+    projects.add_argument('--git', dest='git', default=False,
                           help='Git URL that contains projects')
 
     releases = subparsers.add_parser('releases', help='', parents=[common])


### PR DESCRIPTION
Used urllib to extract easily the project names in every URL provided by the  section of the packages.
In this way we can parse the Git URL (extracted with the net_loc) and receive the projecs (Which is the path) following the [URL Syntactic Components](https://www.rfc-editor.org/rfc/rfc1808.html#section-2.1).