### PR TITLE
Project name should be without zuul.d

### DIFF
--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -170,6 +170,8 @@ def main(argv=None) -> None:
                                             directory))
         jobs = finder.find_jobs(path, templates, triggers)
 
+        # Case where zuul configs are inside zuul.d
+        directory = directory.replace('/zuul.d', '').replace('/.zuul.d', '')
         name = directory.replace('/', '-')
         config_dest = os.path.join(
             GENERATED_CONFIGS_DIR,


### PR DESCRIPTION
For the projects where zuul config files are inside zuul.d directory
it's name should be stripped from the path.