### PR TITLE
Adjust upstream to downstrem name mapping

### DIFF
--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -76,8 +76,18 @@ def get_projects_mapping(**kwawrgs) -> dict:
     projects_mapping = {}
 
     for package in packages:
-        projects_mapping[package['name']] = urlparse(
-            package['osp-patches']).path[1:]
+
+        if 'upstream' in package.keys() and package['upstream']:
+            upstream_name = urlparse(package['upstream']).path[1:]
+            upstream_name = upstream_name.replace("/", "-")
+        else:
+            upstream_name = package['name']
+
+        if 'osp-patches' in package.keys() and package['osp-patches']:
+            projects_mapping[upstream_name] = urlparse(
+                package['osp-patches']).path[1:]
+        else:
+            projects_mapping[upstream_name] = upstream_name
 
     return projects_mapping
 

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -175,10 +175,11 @@ def main(argv=None) -> None:
         # Case where zuul configs are inside zuul.d
         directory = directory.replace('/zuul.d', '').replace('/.zuul.d', '')
         name = directory.replace('/', '-')
-        if name not in us_to_ds_projects_map:
-            ds_name = name
-        else:
+
+        if name in us_to_ds_projects_map.keys():
             ds_name = us_to_ds_projects_map[name]
+        else:
+            ds_name = name
 
         config_dest = os.path.join(
             GENERATED_CONFIGS_DIR,


### PR DESCRIPTION
Some projects have different names and upsrteam repository
names. We should first take repository name as the project
name for znoyder to calculate mappings correctly.