### PR TITLE
Change docker image and add installation commands for apk package man…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: themattrix/tox
+      image: alpine:latest 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2.0.0
-    - name: Tests
-      run: |
-          tox -v
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Package installation
+        run: apk add --no-cache python3 py3-pip && pip3 install tox
+      - name: Tox call tests
+        run: tox -v
+


### PR DESCRIPTION
There's a big difference changing the docker images from Ubuntu to Alpine for this CI. 

-There is a size difference between them (the alpine example size is with a built image I've created with all the packages we need):

```
$ echo $(($(docker image inspect themattrix/tox:latest --format='{{.Size}}' ) / 1000000))
1573
$ echo $(($(docker image inspect alpine_testing --format='{{.Size}}' ) / 1000000))
101
```

- The packages are recent. The ubuntu docker image is 16.04 so it has old version of a lot of packages. 

- It will be faster to build.

