### PR TITLE
Refactor argument parser code

### DIFF
--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -17,9 +17,7 @@
 #
 
 from argparse import ArgumentParser
-from argparse import Namespace
 from pprint import PrettyPrinter
-import sys
 from urllib.parse import urlparse
 
 from distroinfo import info as di
@@ -106,8 +104,7 @@ def get_releases(**kwargs):
     return releases
 
 
-def process_arguments(argv=None) -> Namespace:
-    parser = ArgumentParser(description=APP_DESCRIPTION)
+def extend_parser(parser) -> None:
     subparsers = parser.add_subparsers(dest='command', metavar='command')
 
     common = ArgumentParser(add_help=False)
@@ -132,17 +129,8 @@ def process_arguments(argv=None) -> Namespace:
     releases = subparsers.add_parser('releases', help='', parents=[common])
     releases.add_argument('--tag', dest='tag')
 
-    arguments = parser.parse_args(argv)
 
-    if not arguments.command:
-        parser.print_help()
-        sys.exit(1)
-
-    return arguments
-
-
-def main(argv=None) -> None:
-    args = process_arguments(argv)
+def main(args) -> None:
 
     if args.command == 'components':
         results = get_components(**vars(args))

--- a/znoyder/downloader.py
+++ b/znoyder/downloader.py
@@ -17,7 +17,6 @@
 #
 
 from argparse import ArgumentParser
-from argparse import Namespace
 from functools import partial
 import json
 from multiprocessing import cpu_count
@@ -164,7 +163,7 @@ def download_zuul_config(**kwargs):
     return project_urls
 
 
-def process_arguments(argv=None) -> Namespace:
+def extend_parser(parser) -> None:
     parser = ArgumentParser()
     parser.add_argument(
         '-r', '--repo', '--repository',
@@ -202,12 +201,8 @@ def process_arguments(argv=None) -> Namespace:
         help='do not overwrite existing files'
     )
 
-    arguments = parser.parse_args(argv)
-    return arguments
 
-
-def main(argv=None) -> None:
-    args = process_arguments(argv)
+def main(args) -> None:
 
     download_zuul_config(**vars(args))
 

--- a/znoyder/finder.py
+++ b/znoyder/finder.py
@@ -18,7 +18,6 @@
 
 from argparse import ArgumentParser
 from argparse import ArgumentDefaultsHelpFormatter
-from argparse import Namespace
 import datetime
 import logging
 import os
@@ -104,7 +103,7 @@ def _cli_find_jobs(directory, templates, triggers):
                   (job.job_trigger_type, job, template))
 
 
-def process_arguments(argv=None) -> Namespace:
+def extend_parser(parser) -> None:
     formatter = ArgumentDefaultsHelpFormatter
 
     parser = ArgumentParser(prog='shperer',
@@ -135,13 +134,8 @@ def process_arguments(argv=None) -> Namespace:
                         help='comma separated job trigger types to return',
                         required=True)
 
-    arguments = parser.parse_args(argv)
-    return arguments
 
-
-def main(argv=None) -> None:
-    args = process_arguments(argv)
-
+def main(args) -> None:
     if args.verbose:
         LOG.setLevel(level=logging.DEBUG)
         LOG.debug('Shperer CLI running in debug mode')

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -16,8 +16,6 @@
 #    under the License.
 #
 
-from argparse import ArgumentParser
-from argparse import Namespace
 from copy import deepcopy
 import os.path
 from pathlib import Path
@@ -162,8 +160,7 @@ def cleanup_generated_jobs_dir() -> None:
     Path(destination_directory).mkdir(parents=True, exist_ok=True)
 
 
-def process_arguments(argv=None) -> Namespace:
-    parser = ArgumentParser()
+def extend_parser(parser) -> None:
     parser.add_argument(
         '-e', '--existing',
         dest='existing',
@@ -219,13 +216,8 @@ def process_arguments(argv=None) -> Namespace:
         help='Use defined template name, e.g. empty-zuul-project'
     )
 
-    arguments = parser.parse_args(argv)
-    return arguments
 
-
-def main(argv=None) -> None:
-    args = process_arguments(argv)
-
+def main(args) -> None:
     cleanup_generated_jobs_dir()
 
     if args.download or not(os.path.exists(UPSTREAM_CONFIGS_DIR)):

--- a/znoyder/templater.py
+++ b/znoyder/templater.py
@@ -17,7 +17,6 @@
 #
 
 from argparse import ArgumentParser
-from argparse import Namespace
 from collections import defaultdict
 
 from jinja2 import Environment
@@ -102,7 +101,7 @@ def generate_zuul_config(path: str, name: str,
     return True
 
 
-def process_arguments(argv=None) -> Namespace:
+def extend_parser(args) -> None:
     parser = ArgumentParser()
     parser.add_argument(
         '-j', '--json',
@@ -112,13 +111,8 @@ def process_arguments(argv=None) -> Namespace:
         help='produce output in JSON format'
     )
 
-    arguments = parser.parse_args(argv)
-    return arguments
 
-
-def main(argv=None) -> None:
-    args = process_arguments(argv)
-
+def main(args) -> None:
     if args.json:
         print(JOBS_TO_COLLECT_WITH_MAPPING)
     else:


### PR DESCRIPTION
* Instead of parsing arguments and checking which
  command was used, associate subparsers with specific module

* The commands extend the main parser with subparsers,
  instead of creating their own parsers

* Subparsers are created by iterating over commands dictionary
  which holds the following information: help/description string
  and the module to use for extending the parser & associating
  the module's main function to the subparser
