### PR TITLE
Add ability to redirect generator outptut to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 __pycache__/
 jobs-upstream/
 jobs-generated/
-.eggs
 .coverage
+.eggs
+znoyder_output.log

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -155,7 +155,7 @@ def list_existing_osp_projects() -> list:
 def cleanup_generated_jobs_dir() -> None:
     if os.path.exists(GENERATED_CONFIGS_DIR):
         rmtree(GENERATED_CONFIGS_DIR)
-        LOG.info('Removed the directory: {GENERATED_CONFIGS_DIR}')
+        LOG.info(f'Removed the directory: {GENERATED_CONFIGS_DIR}')
     destination_directory = os.path.dirname(GENERATED_CONFIGS_DIR)
     Path(destination_directory).mkdir(parents=True, exist_ok=True)
 

--- a/znoyder/lib/logger.py
+++ b/znoyder/lib/logger.py
@@ -36,6 +36,8 @@ logger_formatter = colorlog.ColoredFormatter(
     )
 )
 
+file_logger_formater = logging.Formatter(fmt="%(levelname)-8s%(message)s")
+
 LOGGER_NAME = 'znoyderLogger'
 DEFAULT_LOG_LEVEL = logging.INFO
 
@@ -52,6 +54,19 @@ sh.setFormatter(logger_formatter)
 # Create logger and add handler to it
 LOG.addHandler(sh)
 LOG.propagate = False
+
+
+def set_logger_destination(args) -> None:
+    """Ensure that the logger respects the user choice to write to
+    file/stderr/both"""
+    if args.log_mode == "file":
+        # remove log handler that writes to stderr
+        LOG.handlers.pop()
+    if args.log_file and args.log_mode != "terminal":
+        file_handler = logging.FileHandler(args.log_file, mode="w")
+        file_handler.setLevel(DEFAULT_LOG_LEVEL)
+        file_handler.setFormatter(file_logger_formater)
+        LOG.addHandler(file_handler)
 
 
 def znoyder_excepthook(exc_type, exc_value, exc_traceback):


### PR DESCRIPTION
This introduces two cli parameters, log_mode and log_file. The first
gives the user the ability to choose whether to write the ouptut to
stderr, to a file or to both. In case file is selected, the log_file
parameter selects the path to write to.
