### PR TITLE
Fix bug when calling browse-osp with no command

### DIFF
--- a/znoyder/cli.py
+++ b/znoyder/cli.py
@@ -103,7 +103,8 @@ class OverridenSubparserAction(_SubParsersAction):
 
 
 def extend_parser_browser(parser) -> None:
-    subparsers = parser.add_subparsers(dest='command', metavar='command')
+    subparsers = parser.add_subparsers(dest='command', metavar='command',
+                                       required=True)
 
     common = ArgumentParser(add_help=False)
     common.add_argument('--debug', dest='debug',


### PR DESCRIPTION
Before the cli refactor, calling browse-osp with no command would be
manually detected and the program would exit. After the refactor that
check was lost and the program would coninue and crash due to missing
arguments. Adding required=True to the command subparser recovers the
original behavior.
