### PR TITLE
Part 3 of jobs mapper implementation

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -74,7 +74,6 @@ add:
   'gnocchi':
     'osp-17.0':
       'openstack-tox-pep8':
-        voting: false
         type:
           - 'check'
           - 'gate'
@@ -82,7 +81,6 @@ add:
   'keystone':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
           - 'check'
           - 'gate'
@@ -90,49 +88,43 @@ add:
   'openstack-barbican':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
           - 'gate'
 
   'openstack-heat-agents':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
           - 'gate'
 
   'openstack-tripleo-common':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
           - 'gate'
 
   'python-castellan':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
           - 'gate'
 
   'python-keystoneauth1':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
           - 'gate'
 
   'python-keystonemiddleware':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
+          - 'check'
           - 'gate'
 
   'python-openstacksdk':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
           - 'check'
           - 'gate'
@@ -140,9 +132,7 @@ add:
   'python-tripleoclient':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
-          - 'check'
           - 'gate'
         vars:
           rhos_release_args: '17.0'
@@ -150,7 +140,6 @@ add:
   'python-zaqarclient':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         type:
           - 'check'
           - 'gate'
@@ -161,11 +150,31 @@ add:
 #
 # Override map: change options of all the jobs collected so far
 #
+# Format:
+#   '<project-name>':
+#     '<release-tag>':
+#       '<job-name>': {<options...>}
+# e.g.
+#   /.*/:
+#     'osp-17.0':
+#       'openstack-tox-py37':
+#         type: 'check'
+#         voting: false
+#         required-projects: ~
+#
 override:
+  /.*/:  # every project
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: true
+        required-projects: ~
+      'openstack-tox-py39':
+        voting: true
+        required-projects: ~
+
   'aodh':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         vars:
           rhos_release_args: '17.0'
           tox_envlist: 'py39-mysql'
@@ -175,29 +184,16 @@ override:
   'python-ovsdbapp':
     'osp-17.0':
       'openstack-tox-py39':
-        voting: false
         vars:
           rhos_release_args: '17.0'
-
-  'python-swiftclient':
-    'osp-17.0':
-      'openstack-tox-py39':
-        voting: false
 
   'python-tripleoclient':
     'osp-17.0':
       'openstack-tox-pep8':
-        voting: false
-        type:
-          - 'check'
-          - 'gate'
         vars:
           rhos_release_args: '17.0'
       'openstack-tox-py39':
-        voting: false
-        type:
-          - 'check'
-          - 'gate'
+        type: 'check'
         vars:
           rhos_release_args: '17.0'
 

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -16,6 +16,7 @@
 #    under the License.
 #
 
+from copy import deepcopy
 import os.path
 from pathlib import Path
 from shutil import rmtree
@@ -146,6 +147,7 @@ def main(args) -> None:
                                             directory))
         if os.path.exists(path):
             jobs = finder.find_jobs(path, templates, triggers)
+            jobs = deepcopy(jobs)
         else:
             jobs = []
 

--- a/znoyder/lib/zuul.py
+++ b/znoyder/lib/zuul.py
@@ -19,6 +19,7 @@
 #
 
 import collections
+from copy import deepcopy
 import io
 import yaml
 
@@ -426,10 +427,13 @@ class ZuulJob(object):
         job_trigger_type(:obj:`str`): Trigger type e.g. check/gate/post
         job_data(:obj:`dict`): JSON job data
     """
-    def __init__(self, job_name, job_trigger_type, job_data={}):
+    def __init__(self, job_name, job_trigger_type, job_data=None):
+        if job_data is None:
+            job_data = {}
+
         self.job_name = job_name
         self.job_trigger_type = job_trigger_type
-        self.job_data = job_data
+        self.job_data = deepcopy(job_data)
 
     def __str__(self) -> str:
         return self.job_name


### PR DESCRIPTION
- Jobs mapper improvements

This commit introduces changes to jobs mapper that does not
replace all jobs options in override map, but only updates
the defined values and allows us to undefine some jobs options
we may not want to keep by setting them to None (tilde ~ in YAML).
Additional unit tests were introduced to ensure the mechanism
works as expected.

This commit also solved one identified flaw in Zuul library
that caused unexpected behavior due to mess in objects references.
Further investigation and improvements to Zuul library will be
implemented in the future.
 
- Znoyder config update

This commit sets the config map to the currently expected state.
Only necessary set of entries is present right now.