### PR TITLE
Update CI config

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -188,8 +188,32 @@ override:
       'openstack-tox-py39':
         voting: false
 
-  'python-ovsdbapp':
+  'ovn-octavia-provider':  # rhbz#2069526
     'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+      'openstack-tox-py39':
+        voting: false
+
+  'openstack-designate':  # rhbz#2069553
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+      'openstack-tox-py39':
+        voting: false
+
+  'python-neutronclient':  # rhbz#2059099
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+      'openstack-tox-py39':
+        voting: false
+
+  'python-ovsdbapp': # rhos release provides the openvswitch package
+    'osp-17.0':
+      'openstack-tox-pep8':
+        vars:
+          rhos_release_args: '17.0'
       'openstack-tox-py39':
         vars:
           rhos_release_args: '17.0'


### PR DESCRIPTION
Switch jobs which fail CI to non-voting.

In addition, add rhos-release to pep8 job in ovsdbapp since
it requires openvswitch package.
