### PR TITLE
Mark currently unstable jobs as non-voting

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -230,13 +230,19 @@ override:
   'aodh':
     'osp-17.0':
       'openstack-tox-py39':
+        voting: false  # problem with running mysqld in centos container
         vars:
           rhos_release_args: '17.0'
           tox_envlist: 'py39-mysql'
           tox_environment:
             AODH_TEST_DRIVERS: 'mysql'
 
-  'neutron':  # rhbz#2069099
+  'ceilometer':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'ironic-prometheus-exporter':
     'osp-17.0':
       'openstack-tox-pep8':
         voting: false
@@ -244,6 +250,18 @@ override:
         voting: false
 
   'keystone':  # rhbz#2052499
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+      'openstack-tox-py39':
+        voting: false
+
+  'nova':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'neutron':  # rhbz#2069099
     'osp-17.0':
       'openstack-tox-pep8':
         voting: false
@@ -264,10 +282,86 @@ override:
       'openstack-tox-py39':
         voting: false
 
+  'openstack-ec2-api':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'openstack-tripleo-heat-templates':
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+      'openstack-tox-py39':
+        voting: false
+
+  'os-net-config':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'oslo.messaging':
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+      'openstack-tox-py39':
+        voting: false
+
+  'oslo.middleware':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'oslo.vmware':
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+      'openstack-tox-py39':
+        voting: false
+
+  'python-aodhclient':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'python-barbicanclient':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'python-ironicclient':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'python-keystoneclient':
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+
+  'python-kuryr-lib':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'python-neutron-lib':
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+
   'python-neutronclient':  # rhbz#2059099
     'osp-17.0':
       'openstack-tox-pep8':
         voting: false
+      'openstack-tox-py39':
+        voting: false
+
+  'python-openstacksdk':
+    'osp-17.0':
+      'openstack-tox-py39':
+        voting: false
+
+  'python-oslo-config':
+    'osp-17.0':
       'openstack-tox-py39':
         voting: false
 
@@ -280,15 +374,27 @@ override:
         vars:
           rhos_release_args: '17.0'
 
+  'python-proliantutils':
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+
   'python-tripleoclient':
     'osp-17.0':
       'openstack-tox-pep8':
         vars:
           rhos_release_args: '17.0'
       'openstack-tox-py39':
-        type: 'check'
+        voting: false  # one test expects to be run as non-root user
         vars:
           rhos_release_args: '17.0'
+
+  'tripleo-ansible':
+    'osp-17.0':
+      'openstack-tox-pep8':
+        voting: false
+      'openstack-tox-py39':
+        voting: false
 
 
 #


### PR DESCRIPTION
There are numerous of jobs that are still unstable (either
due to still missing dependencies or new issues after jobs
were moved to RHEL 9 environment). To not block the processes
yet, we mark those jobs as non-voting. An investigation
with necessary fixes will be conducted as further action.