### PR TITLE
Rename trigger type to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ It allows investigating details of Zuul configuration that is available
 in the local path.
 
 To get list of jobs and templates defined for a particular project
-and a specified Zuul trigger types, simply execute:
+and specified Zuul pipelines, simply execute:
 
 ```
-znoyder find-jobs --dir path/to/nova --base /path/to/templates/openstack-zuul-jobs --trigger check,gate
+znoyder find-jobs --dir path/to/nova --base /path/to/templates/openstack-zuul-jobs --pipeline check,gate
 ```
 
 There exists the `-v` option for getting a verbose output with many details.

--- a/znoyder/cli.py
+++ b/znoyder/cli.py
@@ -182,9 +182,9 @@ def extend_parser_finder(parser) -> None:
                         help='comma separated paths to jobs templates dirs',
                         required=True)
 
-    parser.add_argument('-t', '--trigger',
-                        dest='trigger',
-                        help='comma separated job trigger types to return',
+    parser.add_argument('-p', '--pipeline',
+                        dest='pipeline',
+                        help='comma separated pipelines to return',
                         required=True)
 
 

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -150,65 +150,65 @@ add:
   'gnocchi':
     'osp-17.0':
       'osp-tox-pep8':
-        type:
+        pipeline:
           - 'check'
           - 'gate'
 
   'keystone':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'check'
           - 'gate'
 
   'openstack-barbican':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'gate'
 
   'openstack-heat-agents':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'gate'
 
   'openstack-tripleo-common':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'gate'
 
   'python-castellan':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'gate'
 
   'python-keystoneauth1':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'gate'
 
   'python-keystonemiddleware':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'check'
           - 'gate'
 
   'python-openstacksdk':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'check'
           - 'gate'
 
   'python-tripleoclient':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'gate'
         vars:
           rhos_release_args: '17.0'
@@ -216,7 +216,7 @@ add:
   'python-zaqarclient':
     'osp-17.0':
       'osp-tox-py39':
-        type:
+        pipeline:
           - 'check'
           - 'gate'
         vars:
@@ -234,7 +234,7 @@ add:
 #   /.*/:
 #     'osp-17.0':
 #       'osp-tox-py37':
-#         type: 'check'
+#         pipeline: 'check'
 #         voting: false
 #         required-projects: ~
 #

--- a/znoyder/finder.py
+++ b/znoyder/finder.py
@@ -28,74 +28,74 @@ from znoyder.lib.exceptions import PathError
 LOG = logger.LOG
 
 
-def find_jobs(directory, templates, triggers):
+def find_jobs(directory, templates, pipelines):
     LOG.debug('Directory: %s' % directory)
 
     project = zuul.ZuulProject(project_path=directory,
                                templates=templates)
 
-    zuul_jobs = project.get_list_of_jobs(triggers)
+    zuul_jobs = project.get_list_of_jobs(pipelines)
 
     project_templates = project.get_list_of_used_templates()
     for template in project_templates:
-        zuul_jobs.extend(template.get_jobs(triggers))
+        zuul_jobs.extend(template.get_jobs(pipelines))
 
     return zuul_jobs
 
 
-def find_templates(directories, triggers):
+def find_templates(directories, pipelines):
     LOG.debug('Directories: %s' % directories)
 
     zuul_templates = []
 
     for directory in directories.split(','):
         project = zuul.ZuulProject(project_path=directory)
-        templates = project.get_list_of_defined_templates(triggers)
+        templates = project.get_list_of_defined_templates(pipelines)
         zuul_templates.extend(templates)
 
     return zuul_templates
 
 
-def find_triggers(triggers):
-    LOG.debug('Triggers: %s' % triggers)
+def find_pipelines(pipelines):
+    LOG.debug('Triggers: %s' % pipelines)
 
-    trigger_types = []
+    pipelines_list = []
 
-    for trigger in triggers.split(','):
-        trigger_types.append(zuul.JobTriggerType.to_type(trigger))
+    for pipeline in pipelines.split(','):
+        pipelines_list.append(zuul.ZuulPipeline.to_type(pipeline))
 
-    return trigger_types
+    return pipelines_list
 
 
-def _cli_find_jobs(directory, templates, triggers):
+def _cli_find_jobs(directory, templates, pipelines):
     LOG.debug('Project dir: %s' % directory)
     LOG.debug('Template dirs: %s' % templates)
-    LOG.debug('Trigger types: %s' % triggers)
+    LOG.debug('Pipelines: %s' % pipelines)
 
-    trigger_types = []
-    for trigger in triggers.split(','):
-        trigger_types.append(zuul.JobTriggerType.to_type(trigger))
+    pipelines_list = []
+    for pipeline in pipelines.split(','):
+        pipelines_list.append(zuul.ZuulPipeline.to_type(pipeline))
 
     zuul_templates = []
 
     for template_dir in templates.split(','):
         project = zuul.ZuulProject(project_path=template_dir)
-        templates = project.get_list_of_defined_templates(trigger_types)
+        templates = project.get_list_of_defined_templates(pipelines_list)
         zuul_templates.extend(templates)
 
     project = zuul.ZuulProject(project_path=directory,
                                templates=zuul_templates)
 
-    zuul_jobs = project.get_list_of_jobs(trigger_types)
+    zuul_jobs = project.get_list_of_jobs(pipelines_list)
 
     for job in zuul_jobs:
-        print('%s: %s' % (job.job_trigger_type, job))
+        print('%s: %s' % (job.pipeline, job))
 
     project_templates = project.get_list_of_used_templates()
     for template in project_templates:
-        for job in template.get_jobs(trigger_types):
+        for job in template.get_jobs(pipelines_list):
             print('%s: %s in template %s' %
-                  (job.job_trigger_type, job, template))
+                  (job.pipeline, job, template))
 
 
 def main(args) -> None:
@@ -110,7 +110,7 @@ def main(args) -> None:
     try:
         _cli_find_jobs(args.directory,
                        args.templates,
-                       args.trigger)
+                       args.pipeline)
 
     except PathError as ex:
         LOG.error(ex.message)

--- a/znoyder/lib/exceptions.py
+++ b/znoyder/lib/exceptions.py
@@ -52,12 +52,7 @@ class PathError(ZnoyderCliException):
         super(self.__class__, self).__init__(msg)
 
 
-class JobTypeError(ZnoyderCliException):
-    def __init__(self, msg):
-        super(self.__class__, self).__init__(msg)
-
-
-class TriggerTypeError(ZnoyderCliException):
+class PipelineError(ZnoyderCliException):
     def __init__(self, msg):
         super(self.__class__, self).__init__(msg)
 

--- a/znoyder/templates/zuul-project-template.j2
+++ b/znoyder/templates/zuul-project-template.j2
@@ -1,14 +1,14 @@
 ---
 - project-template:
     name: {{ name }}
-    {%- for pipeline, jobs in pipelines.items() | sort %}
+    {%- for pipeline, jobs in pipelines | dictsort %}
     {{ pipeline }}:
       jobs:
-        {%- for job in jobs %}
+        {%- for job in jobs | sort(attribute='name') %}
         - {{ job.name }}:
             branches: {{ job.branch }}
             voting: {{ job.voting }}
-            {%- for key, value in job.job_data.items() %}
+            {%- for key, value in job.parameters | dictsort %}
             {{ key }}: {{ value }}
             {%- endfor -%}
         {%- endfor -%}

--- a/znoyder/tests/test_cli.py
+++ b/znoyder/tests/test_cli.py
@@ -97,28 +97,28 @@ class TestCli(TestCase):
     @patch('argparse.ArgumentParser._print_message')
     def test_finder(self, mock_argpare_print):
         """Test parsing of znoyder find-jobs arguments."""
-        cmd = "find-jobs --dir path --base base --trigger check".split()
+        cmd = "find-jobs --dir path --base base --pipeline check".split()
         args = process_arguments(cmd)
         verbose = os.environ.get('SHPERER_VERBOSE', False)
         self.assertEqual(args.verbose, verbose)
         self.assertEqual(args.directory, "path")
         self.assertEqual(args.templates, "base")
-        self.assertEqual(args.trigger, "check")
+        self.assertEqual(args.pipeline, "check")
 
     @patch('argparse.ArgumentParser._print_message')
     def test_finder_missing_dir(self, mock_argpare_print):
         """Test parsing of znoyder find-jobs arguments."""
-        cmd = "find-jobs --base base --trigger check".split()
+        cmd = "find-jobs --base base --pipeline check".split()
         self.assertRaises(SystemExit, process_arguments, cmd)
 
     @patch('argparse.ArgumentParser._print_message')
     def test_finder_missing_base(self, mock_argpare_print):
         """Test parsing of znoyder find-jobs arguments."""
-        cmd = "find-jobs --dir base --trigger check".split()
+        cmd = "find-jobs --dir base --pipeline check".split()
         self.assertRaises(SystemExit, process_arguments, cmd)
 
     @patch('argparse.ArgumentParser._print_message')
-    def test_finder_missing_trigger(self, mock_argpare_print):
+    def test_finder_missing_pipeline(self, mock_argpare_print):
         """Test parsing of znoyder find-jobs arguments."""
         cmd = "find-jobs --dir base --base check".split()
         self.assertRaises(SystemExit, process_arguments, cmd)

--- a/znoyder/tests/test_mapper.py
+++ b/znoyder/tests/test_mapper.py
@@ -48,12 +48,12 @@ class TestJobsGeneratorFromMapEntry(TestCase):
 
     def test_job_generation_without_type(self):
         job_name = 'job_1'
-        job_options = {'opt_1': 'val_1'}
+        job_parameters = {'opt_1': 'val_1'}
 
         add_map.update({
             '/.*/': {
                 '/.*/': {
-                    job_name: job_options
+                    job_name: job_parameters
                 }
             }
         })
@@ -62,19 +62,19 @@ class TestJobsGeneratorFromMapEntry(TestCase):
 
         self.assertIsInstance(result, ZuulJob)
 
-        self.assertEqual(job_name, result.job_name)
-        self.assertEqual('check', result.job_trigger_type)
-        self.assertEqual(job_options, result.job_data)
+        self.assertEqual(job_name, result.name)
+        self.assertEqual('check', result.pipeline)
+        self.assertEqual(job_parameters, result.parameters)
 
     def test_job_generation_with_type(self):
         job_name = 'job_1'
         job_type = 'type'
-        job_options = {'opt_1': 'val_1'}
+        job_parameters = {'opt_1': 'val_1'}
 
         add_map.update({
             '/.*/': {
                 '/.*/': {
-                    job_name: {'type': job_type} | job_options
+                    job_name: {'pipeline': job_type} | job_parameters
                 }
             }
         })
@@ -83,19 +83,19 @@ class TestJobsGeneratorFromMapEntry(TestCase):
 
         self.assertIsInstance(result, ZuulJob)
 
-        self.assertEqual(job_name, result.job_name)
-        self.assertEqual(job_type, result.job_trigger_type)
-        self.assertEqual(job_options, result.job_data)
+        self.assertEqual(job_name, result.name)
+        self.assertEqual(job_type, result.pipeline)
+        self.assertEqual(job_parameters, result.parameters)
 
     def test_job_generation_with_multiple_types(self):
         job_name = 'job_1'
         job_types = ['type1', 'type2']
-        job_options = {'opt_1': 'val_1'}
+        job_parameters = {'opt_1': 'val_1'}
 
         add_map.update({
             '/.*/': {
                 '/.*/': {
-                    job_name: {'type': job_types} | job_options
+                    job_name: {'pipeline': job_types} | job_parameters
                 }
             }
         })
@@ -105,9 +105,9 @@ class TestJobsGeneratorFromMapEntry(TestCase):
         self.assertIsInstance(result, list)
 
         for i in range(len(job_types)):
-            self.assertEqual(job_name, result[i].job_name)
-            self.assertEqual(job_types[i], result[i].job_trigger_type)
-            self.assertEqual(job_options, result[i].job_data)
+            self.assertEqual(job_name, result[i].name)
+            self.assertEqual(job_types[i], result[i].pipeline)
+            self.assertEqual(job_parameters, result[i].parameters)
 
 
 class TestExcludeJobs(TestCase):
@@ -121,13 +121,13 @@ class TestExcludeJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         exclude_map.update({
             '/.*/': {
                 '/.*/': {
-                    job2.job_name: ''
+                    job2.name: ''
                 }
             }
         })
@@ -140,13 +140,13 @@ class TestExcludeJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         exclude_map.update({
             '/.*/': {
                 tag: {
-                    job2.job_name: ''
+                    job2.name: ''
                 }
             }
         })
@@ -160,13 +160,13 @@ class TestExcludeJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         exclude_map.update({
             project: {
                 tag: {
-                    job2.job_name: ''
+                    job2.name: ''
                 }
             }
         })
@@ -180,15 +180,15 @@ class TestExcludeJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         jobs = [job1, job2]
 
         exclude_map.update({
             project: {
                 tag: {
-                    job2.job_name: ''
+                    job2.name: ''
                 }
             }
         })
@@ -204,15 +204,15 @@ class TestExcludeJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         jobs = [job1, job2]
 
         exclude_map.update({
             project: {
                 tag: {
-                    job2.job_name: ''
+                    job2.name: ''
                 }
             }
         })
@@ -230,29 +230,29 @@ class TestAddJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         jobs = [job1, job2]
 
         result = add_jobs(jobs, 'any', 'any')
 
         for i, _ in enumerate(result):
-            self.assertEqual(jobs[i].job_name, result[i].job_name)
+            self.assertEqual(jobs[i].name, result[i].name)
 
     def test_add_by_name(self):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         jobs = [job1]
 
         add_map.update({
             '/.*/': {
                 '/.*/': {
-                    job2.job_name: {}
+                    job2.name: {}
                 }
             }
         })
@@ -260,7 +260,7 @@ class TestAddJobs(TestCase):
         result = add_jobs(jobs, 'any', 'any')
 
         for i, _ in enumerate(result):
-            self.assertEqual([job1, job2][i].job_name, result[i].job_name)
+            self.assertEqual([job1, job2][i].name, result[i].name)
 
     def test_add_by_tag(self):
         tag = 'tag_1'
@@ -268,15 +268,15 @@ class TestAddJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         jobs = [job1]
 
         add_map.update({
             '/.*/': {
                 tag: {
-                    job2.job_name: {}
+                    job2.name: {}
                 }
             }
         })
@@ -284,7 +284,7 @@ class TestAddJobs(TestCase):
         result = add_jobs(jobs, 'any', tag)
 
         for i, _ in enumerate(result):
-            self.assertEqual([job1, job2][i].job_name, result[i].job_name)
+            self.assertEqual([job1, job2][i].name, result[i].name)
 
     def test_add_by_tag_and_project(self):
         tag = 'tag_1'
@@ -293,15 +293,15 @@ class TestAddJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         jobs = [job1]
 
         add_map.update({
             project: {
                 tag: {
-                    job2.job_name: {}
+                    job2.name: {}
                 }
             }
         })
@@ -309,7 +309,7 @@ class TestAddJobs(TestCase):
         result = add_jobs(jobs, project, tag)
 
         for i, _ in enumerate(result):
-            self.assertEqual([job1, job2][i].job_name, result[i].job_name)
+            self.assertEqual([job1, job2][i].name, result[i].name)
 
     def test_add_skip_unmatched_project(self):
         tag = 'tag_1'
@@ -318,15 +318,15 @@ class TestAddJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         jobs = [job1]
 
         add_map.update({
             project: {
                 tag: {
-                    job2.job_name: {}
+                    job2.name: {}
                 }
             }
         })
@@ -342,15 +342,15 @@ class TestAddJobs(TestCase):
         job1 = Mock()
         job2 = Mock()
 
-        job1.job_name = 'job_1'
-        job2.job_name = 'job_2'
+        job1.name = 'job_1'
+        job2.name = 'job_2'
 
         jobs = [job1]
 
         add_map.update({
             project: {
                 tag: {
-                    job2.job_name: {}
+                    job2.name: {}
                 }
             }
         })
@@ -381,15 +381,15 @@ class TestOverrideJobs(TestCase):
         override_map.update({
             '/.*/': {
                 '/.*/': {
-                    job2.job_name: job_data
+                    job2.name: job_data
                 }
             }
         })
 
         override_jobs(jobs, 'any', 'any')
 
-        self.assertDictEqual(job1.job_data, {})
-        self.assertTrue(set(job_data).issubset(set(job2.job_data)))
+        self.assertDictEqual(job1.parameters, {})
+        self.assertTrue(set(job_data).issubset(set(job2.parameters)))
 
     def test_override_by_tag(self):
         tag = 'tag_1'
@@ -404,15 +404,15 @@ class TestOverrideJobs(TestCase):
         override_map.update({
             '/.*/': {
                 tag: {
-                    job2.job_name: job_data
+                    job2.name: job_data
                 }
             }
         })
 
         override_jobs(jobs, 'any', tag)
 
-        self.assertDictEqual(job1.job_data, {})
-        self.assertTrue(set(job_data).issubset(set(job2.job_data)))
+        self.assertDictEqual(job1.parameters, {})
+        self.assertTrue(set(job_data).issubset(set(job2.parameters)))
 
     def test_override_by_tag_and_project(self):
         tag = 'tag_1'
@@ -428,15 +428,15 @@ class TestOverrideJobs(TestCase):
         override_map.update({
             project: {
                 tag: {
-                    job2.job_name: job_data
+                    job2.name: job_data
                 }
             }
         })
 
         override_jobs(jobs, project, tag)
 
-        self.assertDictEqual(job1.job_data, {})
-        self.assertTrue(set(job_data).issubset(set(job2.job_data)))
+        self.assertDictEqual(job1.parameters, {})
+        self.assertTrue(set(job_data).issubset(set(job2.parameters)))
 
     def test_override_skip_unmatched_project(self):
         tag = 'tag_1'
@@ -452,15 +452,15 @@ class TestOverrideJobs(TestCase):
         override_map.update({
             project: {
                 tag: {
-                    job2.job_name: job_data
+                    job2.name: job_data
                 }
             }
         })
 
         override_jobs(jobs, 'any', tag)
 
-        self.assertDictEqual(job1.job_data, {})
-        self.assertDictEqual(job2.job_data, {})
+        self.assertDictEqual(job1.parameters, {})
+        self.assertDictEqual(job2.parameters, {})
 
     def test_override_skip_unmatched_tag(self):
         tag = 'tag_1'
@@ -476,15 +476,15 @@ class TestOverrideJobs(TestCase):
         override_map.update({
             project: {
                 tag: {
-                    job2.job_name: job_data
+                    job2.name: job_data
                 }
             }
         })
 
         override_jobs(jobs, project, 'any')
 
-        self.assertDictEqual(job1.job_data, {})
-        self.assertDictEqual(job2.job_data, {})
+        self.assertDictEqual(job1.parameters, {})
+        self.assertDictEqual(job2.parameters, {})
 
     def test_override_unset_job_option(self):
         tag = 'tag_1'
@@ -501,7 +501,7 @@ class TestOverrideJobs(TestCase):
         override_map.update({
             project: {
                 tag: {
-                    job2.job_name: {
+                    job2.name: {
                         job_data_key: None
                     }
                 }
@@ -510,8 +510,8 @@ class TestOverrideJobs(TestCase):
 
         override_jobs(jobs, project, tag)
 
-        self.assertDictEqual(job1.job_data, {})
-        self.assertDictEqual(job2.job_data, {})
+        self.assertDictEqual(job1.parameters, {})
+        self.assertDictEqual(job2.parameters, {})
         self.assertFalse(job_data == {})
 
 


### PR DESCRIPTION
I have no idea how this change became so big... There are just two commits:

– Rename trigger type to pipeline

    In shperer the entity that aggregates a set of job that should
    be launched on a specific condition was called a trigger type.
    Now we know that the proper term in Zuul terminology is pipeline.
    This commit updates the code to reflect that and set proper
    names everywhere.

– Update config map with new terminology

    After recent Zuul library update, the config map
    should use the new naming convention for parameters.
    TL;DR the `type` is now the `pipeline` in `config.yml`.