### PR TITLE
Add support for filtering by osp-project

### DIFF
--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -58,6 +58,12 @@ def get_packages(**kwargs):
     if kwargs.get('name'):
         packages = [package for package in packages
                     if kwargs.get('name') == package.get('name')]
+    if kwargs.get('osp_name'):
+        packages = [package for package in packages
+                    if kwargs.get('osp_name') == package.get('osp-name')]
+    if kwargs.get('project'):
+        packages = [package for package in packages
+                    if kwargs.get('project') == package.get('project')]
     if kwargs.get('tag'):
         packages = [package for package in packages
                     if kwargs.get('tag') in package.get('tags')]
@@ -67,6 +73,9 @@ def get_packages(**kwargs):
 
     for package in packages:
         package['osp-project'] = urlparse(package['osp-patches']).path[1:]
+    if kwargs.get('osp_project'):
+        packages = [package for package in packages
+                    if kwargs.get('osp_project') == package.get('osp-project')]
 
     return packages
 

--- a/znoyder/cli.py
+++ b/znoyder/cli.py
@@ -121,6 +121,9 @@ def extend_parser_browser(parser) -> None:
     packages = subparsers.add_parser('packages', help='', parents=[common])
     packages.add_argument('--component', dest='component')
     packages.add_argument('--name', dest='name')
+    packages.add_argument('--osp-name', dest='osp_name')
+    packages.add_argument('--osp-project', dest='osp_project')
+    packages.add_argument('--project', dest='project')
     packages.add_argument('--tag', dest='tag')
     packages.add_argument('--upstream', dest='upstream')
 

--- a/znoyder/tests/test_browser.py
+++ b/znoyder/tests/test_browser.py
@@ -142,17 +142,19 @@ class TestGetPackages(TestCase):
 
     def test_search_by_name(self):
         package1 = {
+            'name': 'name_1',
             'osp-name': 'pack_1',
-            'osp-project': '',
-            'osp-patches': 'http://localhost:8080/',
-            'name': 'name_1'
+            'osp-project': 'repo_name_1',
+            'osp-patches': 'http://localhost:8080/repo_name_1',
+            'project': 'project_1',
         }
 
         package2 = {
+            'name': 'name_2',
             'osp-name': 'pack_2',
-            'osp-project': '',
-            'osp-patches': 'http://localhost:8080/',
-            'name': 'name_2'
+            'osp-project': 'repo_name_2',
+            'osp-patches': 'http://localhost:8080/repo_name_2',
+            'project': 'project_2',
         }
 
         packages = [package1, package2]
@@ -166,6 +168,96 @@ class TestGetPackages(TestCase):
         self.assertEqual(
             [package1],
             get_packages(name=package1['name'])
+        )
+
+    def test_search_by_osp_name(self):
+        package1 = {
+            'name': 'name_1',
+            'osp-name': 'pack_1',
+            'osp-project': 'repo_name_1',
+            'osp-patches': 'http://localhost:8080/repo_name_1',
+            'project': 'project_1',
+        }
+
+        package2 = {
+            'name': 'name_2',
+            'osp-name': 'pack_2',
+            'osp-project': 'repo_name_2',
+            'osp-patches': 'http://localhost:8080/repo_name_2',
+            'project': 'project_2',
+        }
+
+        packages = [package1, package2]
+
+        info_call = znoyder.browser.get_distroinfo = Mock()
+
+        info_call.return_value = Mock()
+        info_call.return_value.get = Mock()
+        info_call.return_value.get.return_value = packages
+
+        self.assertEqual(
+            [package1],
+            get_packages(osp_name=package1['osp-name'])
+        )
+
+    def test_search_by_osp_project(self):
+        package1 = {
+            'name': 'name_1',
+            'osp-name': 'pack_1',
+            'osp-project': 'repo_name_1',
+            'osp-patches': 'http://localhost:8080/repo_name_1',
+            'project': 'project_1',
+        }
+
+        package2 = {
+            'name': 'name_2',
+            'osp-name': 'pack_2',
+            'osp-project': 'repo_name_2',
+            'osp-patches': 'http://localhost:8080/repo_name_2',
+            'project': 'project_2',
+        }
+
+        packages = [package1, package2]
+
+        info_call = znoyder.browser.get_distroinfo = Mock()
+
+        info_call.return_value = Mock()
+        info_call.return_value.get = Mock()
+        info_call.return_value.get.return_value = packages
+
+        self.assertEqual(
+            [package1],
+            get_packages(osp_project=package1['osp-project'])
+        )
+
+    def test_search_by_project(self):
+        package1 = {
+            'name': 'name_1',
+            'osp-name': 'pack_1',
+            'osp-project': 'repo_name_1',
+            'osp-patches': 'http://localhost:8080/repo_name_1',
+            'project': 'project_1',
+        }
+
+        package2 = {
+            'name': 'name_2',
+            'osp-name': 'pack_2',
+            'osp-project': 'repo_name_2',
+            'osp-patches': 'http://localhost:8080/repo_name_2',
+            'project': 'project_2',
+        }
+
+        packages = [package1, package2]
+
+        info_call = znoyder.browser.get_distroinfo = Mock()
+
+        info_call.return_value = Mock()
+        info_call.return_value.get = Mock()
+        info_call.return_value.get.return_value = packages
+
+        self.assertEqual(
+            [package1],
+            get_packages(project=package1['project'])
         )
 
     def test_search_by_tag(self):


### PR DESCRIPTION
This commit introduces support for additional filterings
for browse-osp module of Znoyder, including the missing
osp-project that will be crucial for RPM-based jobs.

Jira: OSPCRE-454