### PR TITLE
Implementation of copy mechanism

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -414,4 +414,31 @@ override:
 #
 # Copy map: duplicate a job entry from one pipeline/project to another
 #
-copy: {}  # TODO(sdatko): implement
+# Format:
+#   '<project-name>':
+#     '<release-tag>':
+#       - '<job-name>': {<options...>}
+# e.g.
+#   /.*/:
+#     'osp-17.0':
+#       - 'osp-tox-py37':
+#           from: 'check'
+#           to: 'gate'
+#           as: 'tox-py37'
+#           voting: false
+#           required-projects: ~
+#
+# The `from/to/as` are special keywords in options.
+# Everything else is considered as a job parameter to override after copy.
+#
+# Either `from/to` or `as` is always required (all three are also possible).
+#
+copy:
+  /.*/:  # every project
+    /.*/:  # every tag
+      - 'osp-tox-pep8':
+          from: 'check'
+          to: 'weekly'
+      - 'osp-tox-py39':
+          from: 'check'
+          to: 'weekly'

--- a/znoyder/lib/zuul.py
+++ b/znoyder/lib/zuul.py
@@ -450,3 +450,13 @@ class ZuulJob(object):
 
     def __repr__(self) -> str:
         return self.name
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.pipeline))
+
+    def __eq__(self, other) -> bool:
+        return type(other) is type(self) and (
+            self.name == other.name
+            and self.pipeline == other.pipeline
+            and self.parameters == other.parameters
+        )


### PR DESCRIPTION
Implement hash and eq for ZuulJob

    This commit implements hash function and equality definition
    for the ZuulJob object. It will be useful for identifying
    existences and uniquenesses of the jobs defined.

Implement copy mechanism

    This commit introduces the copy mechanism. It allows to copy jobs:
    – from one pipeline to another,
    – under new name.
    In both variants it is possible to define jobs parameters, similarly
    to how it is done with override map.

Add copy map entries to config

    This commit add all check jobs to the weekly pipeline.
    We will use the periodic (weekly) pipeline for monitoring
    the jobs stability.