### PR TITLE
Add Zuul resources generation

### DIFF
--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -50,6 +50,10 @@ def cleanup_generated_jobs_dir() -> None:
                                          'osp-internal-jobs', 'zuul.d')
     Path(destination_directory).mkdir(parents=True, exist_ok=True)
 
+    destination_directory = os.path.join(GENERATED_CONFIGS_DIR,
+                                         'sf-config', 'resources')
+    Path(destination_directory).mkdir(parents=True, exist_ok=True)
+
 
 def fetch_templates_directory():
     templates_repository = 'https://opendev.org/openstack/openstack-zuul-jobs'
@@ -199,8 +203,24 @@ def generate_projects_config(projects_pipelines_dict: dict) -> None:
     )
 
 
+def generate_resources_config(projects_pipelines_dict: dict) -> None:
+    projects = list(projects_pipelines_dict.keys())
+    config_dest = os.path.join(
+        GENERATED_CONFIGS_DIR,
+        'sf-config', 'resources',
+        'osp-internal' + GENERATED_CONFIG_EXTENSION
+    )
+
+    templater.generate_zuul_resources_config(
+        path=config_dest,
+        projects=projects,
+        prefix=GENERATED_CONFIG_PREFIX
+    )
+
+
 def main(args) -> None:
     cleanup_generated_jobs_dir()
     projects_pipelines_dict = generate_projects_pipleines_dict(args)
     generate_projects_templates(projects_pipelines_dict)
     generate_projects_config(projects_pipelines_dict)
+    generate_resources_config(projects_pipelines_dict)

--- a/znoyder/templater.py
+++ b/znoyder/templater.py
@@ -65,6 +65,17 @@ def generate_zuul_projects_config(path: str, projects: list, prefix: str):
         file.write('\n')
 
 
+def generate_zuul_resources_config(path: str, projects: list, prefix: str):
+    template = j2env.get_template('zuul-resources.j2')
+
+    config = template.render(projects=projects, prefix=prefix)
+    config = config.strip()
+
+    with open(path, 'w') as file:
+        file.write(config)
+        file.write('\n')
+
+
 def main(args) -> None:
     LOG.info('Available templates:')
     for template in j2env.list_templates():

--- a/znoyder/templates/zuul-resources.j2
+++ b/znoyder/templates/zuul-resources.j2
@@ -1,0 +1,34 @@
+---
+resources:
+   tenants:
+      osp-internal:
+         description: OSP Internal tenant – hosting Component CI jobs
+         url: https://sf.hosted.upshift.rdu2.redhat.com/manage
+         default-connection: code.engineering.redhat.com
+         tenant-options:
+            zuul/max-job-timeout: 21600
+            zuul/web-root: https://sf.hosted.upshift.rdu2.redhat.com/zuul/t/osp-internal/
+            zuul/report-build-page: true
+
+   projects:
+      osp-internal:
+         tenant: osp-internal
+         description: OSP Internal tenant – hosting Component CI jobs
+         contacts:
+           - rhos-cre@redhat.com
+         source-repositories:
+         {%- for project in projects | sort %}
+           - {{ project }}:
+               zuul/include: []
+               repoxplorer/skip: true
+               hound/skip: true
+         {%- endfor %}
+           - zuul/zuul-jobs:
+               connection: opendev.org
+               repoxplorer/skip: true
+               hound/skip: true
+           - osp-dfg-compute/segritary:
+               zuul/config-project: True
+               connection: gitlab.cee
+               repoxplorer/skip: true
+               hound/skip: true


### PR DESCRIPTION
This commit introduces a new function that generates
the Zuul resources configuration file, where repositories
available for a given tenant are specified. For supporting
multiple OSP releases, we need to automate this file
generation as well.