### PR TITLE
[tripleo-heat-agents] Install testrepository

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -106,6 +106,10 @@ add:
   'openstack-heat-agents':
     'osp-17.0':
       'osp-rpm-py39':
+        vars:
+          extra_commands:
+            - 'dnf install -y python3-testrepository'
+            - 'dnf reinstall -y platform-python-setuptools'
         pipeline:
           - 'gate'
 


### PR DESCRIPTION
This is required for running the unit tests for the
project tripleo-heat-agents:

"/usr/bin/bash: line 1: testr: command not found"
