### PR TITLE
Fix mistralclient config by adding dependencies

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -427,6 +427,17 @@ override:
           rhos_release_args: '17.0'
           rhos_release_extra_repos: 'rhelosp-17.0-trunk-brew'
 
+  'python-mistralclient':
+    'osp-17.0':
+      'osp-rpm-py39':
+        vars:
+          rhos_release_args: '17.0'
+          rhos_release_extra_repos: 'rhelosp-17.0-trunk-brew'
+          extra_commands:
+            # yamllint disable-line rule:line-length
+            - 'dnf install -y python3-stestr python3-oslotest python3-requests-mock'
+            - 'pip install osprofiler>=1.4.0'
+
   'python-neutron-lib':
     'osp-17.0':
       'osp-rpm-py39':


### PR DESCRIPTION
This is required for running successfully py39 unit tests.
