### PR TITLE
Fix ceilometer config by adding dependencies

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -202,6 +202,14 @@ override:
     'osp-17.0':
       'osp-rpm-py39':
         voting: false
+        vars:
+          rhos_release_args: '17.0'
+          rhos_release_extra_repos: 'rhelosp-17.0-trunk-brew'
+          extra_commands:
+            # yamllint disable-line rule:line-length
+            - 'dnf install -y python3-stestr python3-oslotest python3-testscenarios'
+            # yamllint disable-line rule:line-length
+            - 'pip install os-win>=3.0.0 requests-aws>=0.1.4 confluent-kafka kazoo'
 
   'ironic':
     'osp-17.0':


### PR DESCRIPTION
In order to run successfully py39 unit tests.
