### PR TITLE
Fix openstack-tempest config by adding a dependency

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -102,6 +102,11 @@ add:
       'osp-rpm-py39':
         pipeline:
           - 'check'
+        vars:
+          rhos_release_args: '17.0'
+          rhos_release_extra_repos: 'rhelosp-17.0-trunk-brew'
+          extra_commands:
+            - 'dnf install -y python3-hacking'
 
   'openstack-heat-agents':
     'osp-17.0':


### PR DESCRIPTION
Add installation of python3-hacking in opestack-tempest
config section for CI to pass successfully.
