### PR TITLE
Fix Manila config by adding missing dependencies

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -225,6 +225,16 @@ override:
       'osp-rpm-py39':
         voting: false
 
+  'manila':
+    'osp-17.0':
+      'osp-rpm-py39':
+        vars:
+          rhos_release_args: '17.0'
+          rhos_release_extra_repos: 'rhelosp-17.0-trunk-brew'
+          extra_commands:
+            # yamllint disable-line rule:line-length
+            - 'dnf install -y python3-stestr python3-ddt python3-oslotest python3-testresources python3-requests-mock python3-pycodestyle python3-hacking'
+
   'nova':
     'osp-17.0':
       'osp-rpm-py39':


### PR DESCRIPTION
Add missing dependencies to manila config for py39 tests to
pass successfully.
