### PR TITLE
Fix python-os-win config by adding missing dependencies

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -465,6 +465,16 @@ override:
           rhos_release_args: '17.0'
           rhos_release_extra_repos: 'rhelosp-17.0-trunk-brew'
 
+  'python-os-win':
+    'osp-17.0':
+      'osp-rpm-py39':
+        vars:
+          rhos_release_args: '17.0'
+          rhos_release_extra_repos: 'rhelosp-17.0-trunk-brew'
+          extra_commands:
+            # yamllint disable-line rule:line-length
+            - 'dnf install -y python3-stestr python3-ddt python3-oslotest python3-pycodestyle python3-hacking'
+
   'python-oslo-cache':
     'osp-17.0':
       'osp-rpm-py39':


### PR DESCRIPTION
Required for running py39 tests successfully.
