### PR TITLE
Tool predictability improvements

### DIFF
--- a/znoyder/cli.py
+++ b/znoyder/cli.py
@@ -192,21 +192,18 @@ def extend_parser_finder(parser) -> None:
 
 
 def extend_parser_generator(parser) -> None:
-    parser.add_argument(
-        '-c', '--component',
-        dest='component',
-        help='OSP component name to filter projects'
-    )
-    parser.add_argument(
-        '-n', '--name',
-        dest='name',
-        help='OSP package name to filter projects'
-    )
-    parser.add_argument(
-        '-t', '--tag',
-        dest='tag',
-        help='OSP release tag to filter projects'
-    )
+    parser.add_argument('--component', dest='component',
+                        help='OSP component name to filter projects')
+    parser.add_argument('--name', dest='name',
+                        help='package name to filter projects')
+    parser.add_argument('--osp-name', dest='osp_name',
+                        help='OSP package name to filter projects')
+    parser.add_argument('--osp-project', dest='osp_project',
+                        help='OSP project name to filter projects')
+    parser.add_argument('--project', dest='project',
+                        help='project name to filter projects')
+    parser.add_argument('--tag', dest='tag',
+                        help='OSP release tag to filter projects')
 
 
 def extend_parser_templater(parser) -> None:

--- a/znoyder/finder.py
+++ b/znoyder/finder.py
@@ -30,17 +30,18 @@ LOG = logger.LOG
 
 def find_jobs(directory, templates, pipelines):
     LOG.debug('Directory: %s' % directory)
+    zuul_jobs = set()
 
     project = zuul.ZuulProject(project_path=directory,
                                templates=templates)
 
-    zuul_jobs = project.get_list_of_jobs(pipelines)
+    zuul_jobs.update(project.get_list_of_jobs(pipelines))
 
     project_templates = project.get_list_of_used_templates()
-    for template in project_templates:
-        zuul_jobs.extend(template.get_jobs(pipelines))
+    for template in reversed(project_templates):
+        zuul_jobs.update(template.get_jobs(pipelines))
 
-    return zuul_jobs
+    return list(zuul_jobs)
 
 
 def find_templates(directories, pipelines):

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -129,10 +129,16 @@ def generate_projects_pipleines_dict(args):
         downstream_branch = branches_map.get(osp_tag, {}).get('downstream')
 
         ospinfo_filters = {'tag': osp_tag}
-        if args.name:
-            ospinfo_filters['name'] = args.name
         if args.component:
             ospinfo_filters['component'] = args.component
+        if args.name:
+            ospinfo_filters['name'] = args.name
+        if args.osp_name:
+            ospinfo_filters['osp_name'] = args.osp_name
+        if args.osp_project:
+            ospinfo_filters['osp_project'] = args.osp_project
+        if args.project:
+            ospinfo_filters['project'] = args.project
 
         LOG.info('Downloading Zuul configuration from upstream...')
         LOG.info(f'Zuul configuration files: {UPSTREAM_CONFIGS_DIR}')

--- a/znoyder/lib/zuul.py
+++ b/znoyder/lib/zuul.py
@@ -458,5 +458,11 @@ class ZuulJob(object):
         return type(other) is type(self) and (
             self.name == other.name
             and self.pipeline == other.pipeline
+        )
+
+    def really_equal(self, other) -> bool:
+        return type(other) is type(self) and (
+            self.name == other.name
+            and self.pipeline == other.pipeline
             and self.parameters == other.parameters
         )

--- a/znoyder/mapper.py
+++ b/znoyder/mapper.py
@@ -17,7 +17,6 @@
 #
 
 from copy import deepcopy
-import re
 import sys
 
 from znoyder.config import add_map
@@ -27,47 +26,13 @@ from znoyder.config import include_map
 from znoyder.config import override_map
 from znoyder.lib import logger
 from znoyder.lib.zuul import ZuulJob
+from znoyder.utils import drop_nones_from_dict
+from znoyder.utils import match
+from znoyder.utils import merge_dicts
+from znoyder.utils import sort_dict_by_keys
 
 
 LOG = logger.LOG
-
-
-def match(string: str, specifier: str) -> bool:
-    '''Function checks if a given string is matched by a given specifier.
-
-    The match is performed in the awk-inspired fashion:
-    – if the specifier starts and ends with the forward slash (/), e.g. /foo/,
-      then the content between slashes is treated as regular expression,
-    – otherwise it is a value that should fully match the input string.
-
-    Parameters
-    ----------
-    string : str
-        The string that should be tested against specifier.
-    specifier : str
-        The expected value or regular expression to be matched against.
-
-    Returns
-    -------
-    matched : bool
-        True if given string matches the specifier, False otherwise.
-
-    Examples
-    --------
-    >>> match('foobar', 'foobar')
-    True
-    >>> match('foobar', 'foo')
-    False
-    >>> match('foobar', '/foo/')
-    True
-    '''
-
-    if specifier.startswith('/') and specifier.endswith('/'):
-        regex = re.compile(specifier[1:-2])
-        return bool(regex.search(string))
-    else:
-        regex = re.compile(specifier)
-        return bool(regex.fullmatch(string))
 
 
 def new_jobs_from_map_entry(entry: dict) -> ZuulJob:
@@ -82,17 +47,14 @@ def new_jobs_from_map_entry(entry: dict) -> ZuulJob:
 
 
 def update_jobs_from_map_entry(jobs: list, entry: dict) -> list:
-    job_name, job_options = entry
+    job_name, job_options = deepcopy(entry)
     pipeline = job_options.pop('pipeline', '/.*/')  # any pipeline by default
 
     for index, job in enumerate(jobs):
-        if (match(job.name, job_name)
-                and match(job.pipeline, pipeline)):
-            jobs[index].parameters.update(job_options)
-
-            for key, value in jobs[index].parameters.copy().items():
-                if value is None:
-                    del jobs[index].parameters[key]
+        if match(job.name, job_name) and match(job.pipeline, pipeline):
+            merge_dicts(jobs[index].parameters, job_options, override=True)
+            drop_nones_from_dict(jobs[index].parameters)
+            sort_dict_by_keys(jobs[index].parameters)
 
     return jobs
 
@@ -113,11 +75,10 @@ def copy_jobs_from_map_entry(jobs: list, entry: dict) -> list:
     for index, job in enumerate(jobs):
         if match(job.name, job_name) and match(job.pipeline, pipeline):
             new_job = deepcopy(job)
-            new_job.parameters.update(job_options)
 
-            for key, value in new_job.parameters.copy().items():
-                if value is None:
-                    del new_job.parameters[key]
+            merge_dicts(new_job.parameters, job_options, override=True)
+            drop_nones_from_dict(new_job.parameters)
+            sort_dict_by_keys(new_job.parameters)
 
             if new_name:
                 new_job.name = new_name

--- a/znoyder/tests/test_mapper.py
+++ b/znoyder/tests/test_mapper.py
@@ -26,20 +26,12 @@ from znoyder.mapper import copy_map
 from znoyder.mapper import copy_jobs
 from znoyder.mapper import exclude_map
 from znoyder.mapper import exclude_jobs
-from znoyder.mapper import match
 from znoyder.mapper import override_map
 from znoyder.mapper import override_jobs
 from znoyder.lib.zuul import ZuulJob
 
 
 logging.disable(logging.CRITICAL)
-
-
-class TestMatcher(TestCase):
-    def test_match(self):
-        self.assertTrue(match('foobar', 'foobar'))
-        self.assertFalse(match('foobar', 'foo'))
-        self.assertTrue(match('foobar', '/foo/'))
 
 
 class TestJobsGeneratorFromMapEntry(TestCase):

--- a/znoyder/tests/test_utils.py
+++ b/znoyder/tests/test_utils.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+from unittest import TestCase
+
+from znoyder.utils import drop_nones_from_dict
+from znoyder.utils import match
+from znoyder.utils import merge_dicts
+from znoyder.utils import sort_dict_by_keys
+
+
+class TestDropper(TestCase):
+    def test_drop_nones_from_dict(self):
+        actual = drop_nones_from_dict({'a': 1, 'b': 2, 'c': None})
+        expected = {'a': 1, 'b': 2}
+        self.assertEqual(actual, expected)
+
+        actual = drop_nones_from_dict({'a': 1, 'b': {'c': 2, 'd': None}})
+        expected = {'a': 1, 'b': {'c': 2}}
+        self.assertEqual(actual, expected)
+
+
+class TestMatcher(TestCase):
+    def test_match(self):
+        self.assertTrue(match('foobar', 'foobar'))
+        self.assertFalse(match('foobar', 'foo'))
+        self.assertTrue(match('foobar', '/foo/'))
+
+
+class TestMerger(TestCase):
+    def test_merge_dicts(self):
+        actual = merge_dicts({'a': 1, 'b': 2}, {'b': 2})
+        expected = {'a': 1, 'b': 2}
+        self.assertEqual(actual, expected)
+
+        actual = merge_dicts({'a': 1, 'b': {'c': 2}}, {'b': {'d': 3}})
+        expected = {'a': 1, 'b': {'c': 2, 'd': 3}}
+        self.assertEqual(actual, expected)
+
+        self.assertRaises(Exception, merge_dicts,
+                          {'a': 1, 'b': {'c': 2}}, {'b': {'c': 3}})
+
+
+class TestSorter(TestCase):
+    def test_sort_dict_by_keys(self):
+        actual = sort_dict_by_keys({'b': 1, 'a': 4, 'c': 3})
+        expected = {'a': 4, 'b': 1, 'c': 3}
+        self.assertEqual(actual, expected)
+
+        actual = sort_dict_by_keys({'b': {'g': 6, 'e': 7, 'f': 5}, 'a': 4})
+        expected = {'a': 4, 'b': {'e': 7, 'f': 5, 'g': 6}}
+        self.assertEqual(actual, expected)

--- a/znoyder/utils.py
+++ b/znoyder/utils.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+import re
+
+
+def drop_nones_from_dict(collection: dict) -> dict:
+    '''Deletes keys from dictionary in place where values are set to None.
+
+    Parameters
+    ----------
+    collection : dict
+        The dictionary to process.
+
+    Returns
+    -------
+    collection : dict
+        The input dictionary without any key that had value set to None.
+
+    Examples
+    --------
+    >>> drop_nones_from_dict({'a': 1, 'b': 2, 'c': None})
+    {'a': 1, 'b': 2}
+    >>> drop_nones_from_dict({'a': 1, 'b': {'c': 2, 'd': None}})
+    {'a': 1, 'b': {'c': 2}}
+    '''
+
+    for key, value in collection.copy().items():
+        if isinstance(collection[key], dict):
+            drop_nones_from_dict(collection[key])
+        elif value is None:
+            del collection[key]
+
+    return collection
+
+
+def match(string: str, specifier: str) -> bool:
+    '''Function checks if a given string is matched by a given specifier.
+
+    The match is performed in the awk-inspired fashion:
+    – if the specifier starts and ends with the forward slash (/), e.g. /foo/,
+      then the content between slashes is treated as regular expression,
+    – otherwise it is a value that should fully match the input string.
+
+    Parameters
+    ----------
+    string : str
+        The string that should be tested against specifier.
+    specifier : str
+        The expected value or regular expression to be matched against.
+
+    Returns
+    -------
+    matched : bool
+        True if given string matches the specifier, False otherwise.
+
+    Examples
+    --------
+    >>> match('foobar', 'foobar')
+    True
+    >>> match('foobar', 'foo')
+    False
+    >>> match('foobar', '/foo/')
+    True
+    '''
+
+    if specifier.startswith('/') and specifier.endswith('/'):
+        regex = re.compile(specifier[1:-2])
+        return bool(regex.search(string))
+    else:
+        regex = re.compile(specifier)
+        return bool(regex.fullmatch(string))
+
+
+def merge_dicts(a: dict, b: dict, path=None, override=False) -> dict:
+    '''Merges dict `b` into dict `a` in place and also returns updated `a`.
+
+    Inspired by https://stackoverflow.com/a/7205107
+
+    Parameters
+    ----------
+    a : dict
+        The first dictionary, the one that should be updated.
+    b : str
+        The second dictionary, that shall be merged into the first one.
+
+    Returns
+    -------
+    a : dict
+        The first dict after being merged with second dict.
+
+    Examples
+    --------
+    >>> merge_dicts({'a': 1, 'b': 2}, {'b': 2})
+    {'a': 1, 'b': 2}
+    >>> merge_dicts({'a': 1, 'b': {'c': 2}}, {'b': {'d': 3}})
+    {'a': 1, 'b': {'c': 2, 'd': 3}}
+    >>> merge_dicts({'a': 1, 'b': {'c': 2}}, {'b': {'c': 3}})
+    Traceback (most recent call last):
+     ...
+    Exception: Conflict at path: b.c
+    '''
+
+    if path is None:
+        path = []
+
+    if b:
+        for key in b:
+            if a and key in a:
+                if isinstance(a[key], dict) and isinstance(b[key], dict):
+                    merge_dicts(a[key], b[key], path + [str(key)], override)
+                elif a[key] == b[key]:
+                    pass
+                elif not a[key] and b[key] or override:
+                    a[key] = b[key]
+                else:
+                    path = '.'.join(path + [str(key)])
+                    raise Exception(f'Conflict at path: {path}')
+            else:
+                a[key] = b[key]
+
+    return a
+
+
+def sort_dict_by_keys(collection: dict) -> dict:
+    '''Nested sort of the dictionary elements in place by keys.
+
+    Parameters
+    ----------
+    collection : dict
+        The dictionary to process.
+
+    Returns
+    -------
+    collection : dict
+        The sorted dictionary.
+
+    Examples
+    --------
+    >>> sort_dict_by_keys({'b': 1, 'a': 4, 'c': 3})
+    {'a': 4, 'b': 1, 'c': 3}
+    >>> sort_dict_by_keys({'b': {'g': 6, 'e': 7, 'f': 5}, 'a': 4, 'c': 3})
+    {'a': 4, 'b': {'e': 7, 'f': 5, 'g': 6}, 'c': 3}
+    '''
+
+    data = collection.copy()
+    collection.clear()
+
+    collection.update(dict(sorted(data.items())))
+
+    for key, value in collection.copy().items():
+        if isinstance(collection[key], dict):
+            sort_dict_by_keys(collection[key])
+
+    return collection


### PR DESCRIPTION
This pull request contains the following changes listed below.

> Extend filtering for generator

This commit introduces additional command line arguments
for generator subcommand, allowing to generate Zuul configs
only for a particular OSP project easier.

> Prevent jobs duplicates during include

For some upstream project, there is a situation where the same
job is defined in multiple places, e.g. in a project-template
and a project itself. Our finder implementation in such case
included the job twice, which was incorrect behavior – the latter
definition in the tree (template -> template -> project) should
always overwrite the previous definition in such case.
This commit introduces a solution for mentioned problem
by involving a set object and traversing the list of templates
in reversed order. The hash function for a ZuulJob object
is defined over a pair of job name and job pipeline,
so it properly covers the shadowing of previous definitions,
at least according to conducted tests ;-)

> Improve output's predictability

This commit improves the mapper code to produce more predictable
output by Znoyder every time. As design choice, we want some
elements in Zuul configuration in a fixed order, e.g. name, branch
and voting attributes on top of definitions, while all additional
arguments should be ordered alphabetically. Additionally for nested
values, like during updating the job's vars parameters, for user's
convenience we would like to extend the dictionary instead of
overriding it completely. This requires us to perform nested lookups
over the defined jobs and perform actions in that fashion, hence
helper utilities were defined.