### PR TITLE
General enchancements

### DIFF
--- a/tools/generate-components-projects-dict.sh
+++ b/tools/generate-components-projects-dict.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+znoyder browse-osp packages --output component,osp-project \
+    | sort --key 1,2 \
+    | uniq \
+    | gawk '
+      function add(array, component, project) {
+          array[component][length(array[component]) + 1] = project
+      }
+      NF == 2 {
+          component = $1
+          project = $2
+          add(projects, component, project)
+      }
+      END {
+          print "---"
+          PROCINFO["sorted_in"] = "@val_num_asc"
+          for(component in projects) {
+              print component ":"
+              for(key in projects[component]) {
+                  print "  - " projects[component][key]
+              }
+          }
+      }
+      ' \
+    | tee projects.yml 

--- a/znoyder/browser.py
+++ b/znoyder/browser.py
@@ -143,4 +143,4 @@ def main(args) -> None:
 
     if results:
         for result in results:
-            print(' '.join([result.get(key, 'None') for key in output]))
+            print(' '.join([str(result.get(key, 'None')) for key in output]))

--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -36,15 +36,15 @@ include:
   'osp-17.0':
     'openstack-tox-pep8': 'osp-tox-pep8'
     'openstack-tox-py39': 'osp-rpm-py39'
-    'openstack-tox-functional-py39': 'osp-tox-functional-py39'
-    'cinder-tox-functional-py39': 'cinder-tox-functional-py39'
-    'nova-tox-functional-py39': 'nova-tox-functional-py39'
-    'placement-nova-tox-functional-py39': 'placement-nova-tox-functional-py39'
+    # 'openstack-tox-functional-py39': 'osp-tox-functional-py39'
+    # 'cinder-tox-functional-py39': 'cinder-tox-functional-py39'
+    # 'nova-tox-functional-py39': 'nova-tox-functional-py39'
+    # 'placement-nova-tox-functional-py39': 'placement-nova-tox-functional-py39'
     # yamllint disable-line rule:line-length
-    'glance-tox-functional-py39-cursive-tips': 'glance-tox-functional-py39-cursive-tips'
+    # 'glance-tox-functional-py39-cursive-tips': 'glance-tox-functional-py39-cursive-tips'
     # yamllint disable-line rule:line-length
-    'glance-tox-functional-py39-rbac-defaults': 'glance-tox-functional-py39-rbac-defaults'
-    'openstack-tox-functional': 'osp-tox-functional'
+    # 'glance-tox-functional-py39-rbac-defaults': 'glance-tox-functional-py39-rbac-defaults'
+    # 'openstack-tox-functional': 'osp-tox-functional'
 
 
 #

--- a/znoyder/generator.py
+++ b/znoyder/generator.py
@@ -148,6 +148,11 @@ def generate_projects_pipleines_dict(args):
             filters=ospinfo_filters,
         )
 
+        if not projects:
+            LOG.warning('Did not find any projects using following filters: '
+                        f'{ospinfo_filters}.')
+            continue
+
         path = os.path.abspath(os.path.join(UPSTREAM_CONFIGS_DIR,
                                             templates_directory))
 

--- a/znoyder/mapper.py
+++ b/znoyder/mapper.py
@@ -99,7 +99,7 @@ def include_jobs(jobs, tag) -> list:
 
     for job in upstream_jobs:
         if job.name not in jobs_to_collect:
-            LOG.warning(f'Ignoring job: {job.name}')
+            LOG.warning(f'Ignoring job: {job.name} ({job.pipeline})')
             continue
 
         if jobs_to_collect.get(job.name) is not None:

--- a/znoyder/templater.py
+++ b/znoyder/templater.py
@@ -16,6 +16,7 @@
 #    under the License.
 #
 
+import math
 import os
 
 from jinja2 import Environment
@@ -46,6 +47,7 @@ def generate_zuul_project_template(path: str, name: str, pipelines: dict):
         Dumper=NestedDumper,
         default_flow_style=False,
         sort_keys=False,
+        width=math.inf,
     )
     config = config.strip()
 


### PR DESCRIPTION
This pull requests includes the following changes.

> Disable functional jobs

    This effort has to be rewised and retriaged.
    For now let's disable generation of those jobs.

> Add tool to generate projects dict

    This commit introduces small tool that can be used
    for generating a YAML dictionary with components
    and projects assigned to them. It can be later used
    for example in Zuul Jobs Board.

> Prevent lines wrapping in generated configs

    This commit adds a parameter to the dump function
    of PyYAML so it no longer wraps too long lines.

> Minor output improvements

    This commit brings small additions to make the user
    experience a little better – with more details about
    included jobs, warning when no projects were found
    (e.g. specified wrong component) and allowing to print
    list elements with `browse-osp` subcommand.