### PR TITLE
Add initial jobs OSP-17.1

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -648,9 +648,20 @@ override:
 copy:
   /.*/:  # every project
     /.*/:  # every tag
+      - 'osp-rpm-py39':
+          from: 'check'
+          to: 'weekly'
       - 'osp-tox-pep8':
           from: 'check'
           to: 'weekly'
       - 'osp-rpm-py39':
-          from: 'check'
-          to: 'weekly'
+          as: 'osp-rpm-py39'
+          branches: '^rhos-17.1-trunk-patches$'
+          vars:
+            rhos_release_args: '17.1'
+            rhos_release_extra_repos: 'rhelosp-17.1-trunk-brew'
+          voting: false
+      - 'osp-tox-pep8':
+          as: 'osp-tox-pep8'
+          branches: '^rhos-17.1-trunk-patches$'
+          voting: false

--- a/znoyder/mapper.py
+++ b/znoyder/mapper.py
@@ -65,7 +65,8 @@ def copy_jobs_from_map_entry(jobs: list, entry: dict) -> list:
     new_pipeline = job_options.pop('to', None)
     new_name = job_options.pop('as', job_name)
 
-    if job_name == new_name and not new_pipeline:
+    if all([job_name == new_name, not new_pipeline,
+            'branches' not in job_options]):
         LOG.error(f'Bad entry definition: {entry}')
         LOG.error('Target pipeline or unique new name shall be specified.')
         sys.exit(1)


### PR DESCRIPTION
This commit utilizes the copy mechanism of Znoyder and the amazing
shadowing effect in YAML files to generate initial list of jobs
for OSP 17.1 release. Basically, all jobs are copied under the same
name, but with additional `branches` parameter, which overrides
the default value added there from template.

This is not final solution, but for now, as we work on stabilizing
the jobs for OSP 17.0, it would provide us with initial results.
Then, the proper including, adding and overriding will be implemented
instead of the copy map entries.