### PR TITLE
Applying fixes for python-cinderclient

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -498,7 +498,9 @@ override:
   'python-cinderclient':
     'osp-17.0':
       'osp-rpm-py39':
-        voting: false
+        voting: true
+        vars:
+          allow_test_requirements_txt: true
 
   'python-cliff':
     'osp-17.0':


### PR DESCRIPTION
Enabling test-requirements.txt on the rpm job.

That change fixes the job, as seen here: https://code.engineering.redhat.com/gerrit/c/python-cinderclient/+/421404