### PR TITLE
Fixing python-saharaclient

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -746,7 +746,15 @@ override:
   'python-saharaclient':
     'osp-17.0':
       'osp-rpm-py39':
-        voting: false
+        voting: true
+        vars:
+          allow_test_requirements_txt: true
+          extra_commands:
+            - dnf remove -y python3-pbr
+            - pip install oslo.serialization
+            - pip install keystoneauth1
+            - pip install osc-lib
+            - pip install oslo.log
 
   'python-scciclient':
     'osp-17.0':


### PR DESCRIPTION
Removing conflicting rpm package. 
Installing dependencies through pip.
Enabling test-requirements.