### PR TITLE
Apply first step to fix python-os-brick

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -657,6 +657,8 @@ override:
     'osp-17.0':
       'osp-rpm-py39':
         voting: false
+        vars:
+          allow_test_requirements_txt: true
       'osp-tox-pep8':
         voting: false
 


### PR DESCRIPTION
Enabling test-requirements.txt

After that the job still fails with a 'invalid use_2to3' error which I have no been able to fix. Once this is merged in and I have a build with that I will publish a but ticket for it.