### PR TITLE
Fix oslo-config and octavia-ui configs

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -385,6 +385,10 @@ override:
     'osp-17.0':
       'osp-rpm-py39':
         voting: false
+        vars:
+          extra_commands:
+            - 'dnf install -y openstack-dashboard'
+            - 'ln -s /usr/share/openstack-dashboard/openstack_dashboard /usr/lib/python3.9/site-packages/'
 
   'openstack-tripleo-common':
     'osp-17.0':
@@ -490,7 +494,7 @@ override:
         vars:
           extra_commands:
             - 'dnf install -y python3-coverage python3-stestr python3-requests-mock openstack-dashboard'
-            - 'ln -s /usr/share/openstack-dashboard/ /usr/lib/python3.9/site-packages/'
+            - 'ln -s /usr/share/openstack-dashboard/openstack_dashboard /usr/lib/python3.9/site-packages/'
 
   'python-castellan':
     'osp-17.0':
@@ -712,9 +716,7 @@ override:
       'osp-rpm-py39':
         voting: false
         vars:
-          extra_commands:
-            - 'dnf install -y python3-stestr python3-oslotest python3-oslo-sphinx python3-docutils python3-requests-mock python3-testscenarios python3-oslo-log'
-            - 'pip install sphinx'
+          allow_test_requirements_txt: true
 
   'python-oslo-context':
     'osp-17.0':


### PR DESCRIPTION
Fix symlink for dashboard content (which isn't installed by default
in Python path) for octavia-ui and replace DNF installation with
test-requirements.txt installation for oslo-config.
