### PR TITLE
Update oslo-config configuration to use test-reqs

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -712,9 +712,7 @@ override:
       'osp-rpm-py39':
         voting: false
         vars:
-          extra_commands:
-            - 'dnf install -y python3-stestr python3-oslotest python3-oslo-sphinx python3-docutils python3-requests-mock python3-testscenarios python3-oslo-log'
-            - 'pip install sphinx'
+          allow_test_requirements_txt: true
 
   'python-oslo-context':
     'osp-17.0':


### PR DESCRIPTION
Instead of manually specifying the RPM test dependencies
and mixing it with pip dependencies, this change sets
allow_test_requirements_txt to true to use it as a source
for the test dependencies (project dependencies are still used
from RPMs).
