### PR TITLE
Removing gate constraint to add job to weekly

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -163,21 +163,15 @@ add:
   'swift':
     'osp-17.0':
       'osp-rpm-py39':
-        pipeline:
-          - 'gate'
         branches: ^rhos-17.0-trunk-patches$
         voting: false
         vars:
           rhos_release_args: '17.0'
           rhos_release_extra_repos: rhelosp-17.0-trunk-brew
           extra_commands:
-            # yamllint disable-line rule:line-length
             - 'dnf install -y python3-swift-tests python3-nose-1.3.7 python3-dns python3-coverage python3-mock python3-requests-mock liberasurecode-devel'
-            # yamllint disable-line rule:line-length
             - 'cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf'
-            # yamllint disable-line rule:line-length
             - "sed -i -r 's/swift_hash_path_suffix = %SWIFT_HASH_PATH_SUFFIX%/swift_hash_path_suffix = testing/' /etc/swift/swift.conf"
-            # yamllint disable-line rule:line-length
             - "sed -i -r '/self.assertEqual(expected_args, syslog_handler_args)/d' /root/src/code.engineering.redhat.com/swift/test/unit/common/test_utils.py"
       'osp-tox-pep8':
         branches: ^rhos-17.0-trunk-patches$
@@ -189,7 +183,6 @@ add:
           rhos_release_args: '17.0'
           rhos_release_extra_repos: rhelosp-17.0-trunk-brew
           extra_commands:
-            # yamllint disable-line rule:line-length
             - 'dnf install -y python3-swift python3-nose python3-mock liberasurecode-devel'
 
 


### PR DESCRIPTION
This change erases the pipeline parameter for the job to be added to both "check" and "gate", thus making it also available on the weekly run.