### PR TITLE
Fixed "sed" command by removing -r option

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -172,7 +172,7 @@ add:
             - 'dnf install -y python3-swift-tests python3-nose-1.3.7 python3-dns python3-coverage python3-mock python3-requests-mock liberasurecode-devel'
             - 'cp /usr/lib/python3.9/site-packages/swift/test/sample.conf /etc/swift/test.conf'
             - "sed -i -r 's/swift_hash_path_suffix = %SWIFT_HASH_PATH_SUFFIX%/swift_hash_path_suffix = testing/' /etc/swift/swift.conf"
-            - "sed -i -r '/self.assertEqual(expected_args, syslog_handler_args)/d' /root/src/code.engineering.redhat.com/swift/test/unit/common/test_utils.py"
+            - "sed -i '/self.assertEqual(expected_args, syslog_handler_args)/d' /root/src/code.engineering.redhat.com/swift/test/unit/common/test_utils.py"
       'osp-tox-pep8':
         branches: ^rhos-17.0-trunk-patches$
         voting: false


### PR DESCRIPTION
Swift was failing on our weekly testing for rpm-based jobs.
The error comes from the "sed" command I used to disable a test.
This will fix the issue and Swift will pass.