### PR TITLE
Rewise gating jobs

### DIFF
--- a/znoyder/config.yml
+++ b/znoyder/config.yml
@@ -86,42 +86,10 @@ add:
       'osp-tox-pep8':
         pipeline:
           - 'check'
-          - 'gate'
     'osp-17.1':
       'osp-tox-pep8':
         pipeline:
           - 'check'
-          - 'gate'
-
-  'keystone':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-
-  'openstack-barbican':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-
-  'openstack-heat-agents':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
 
   'openstack-tempest':
     'osp-17.0':
@@ -139,76 +107,31 @@ add:
           extra_commands:
             - 'dnf install -y python3-hacking'
 
-  'openstack-tripleo-common':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-
-  'python-castellan':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-
-  'python-keystoneauth1':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-
   'python-keystonemiddleware':
     'osp-17.0':
       'osp-rpm-py39':
         pipeline:
           - 'check'
-          - 'gate'
     'osp-17.1':
       'osp-rpm-py39':
         pipeline:
           - 'check'
-          - 'gate'
 
   'python-openstacksdk':
     'osp-17.0':
       'osp-rpm-py39':
         pipeline:
           - 'check'
-          - 'gate'
     'osp-17.1':
       'osp-rpm-py39':
         pipeline:
           - 'check'
-          - 'gate'
-
-  'python-tripleoclient':
-    'osp-17.0':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
-    'osp-17.1':
-      'osp-rpm-py39':
-        pipeline:
-          - 'gate'
 
   'python-zaqarclient':
     'osp-17.0':
       'osp-rpm-py39':
         pipeline:
           - 'check'
-          - 'gate'
         vars:
           extra_commands:
             - 'dnf install -y python3-pbr python3-stestr python3-osc-lib-tests python3-ddt python3-oslotest python3-testresources python3-requests-mock python3-pycodestyle python3-hacking'
@@ -216,7 +139,6 @@ add:
       'osp-rpm-py39':
         pipeline:
           - 'check'
-          - 'gate'
         vars:
           extra_commands:
             - 'dnf install -y python3-pbr python3-stestr python3-osc-lib-tests python3-ddt python3-oslotest python3-testresources python3-requests-mock python3-pycodestyle python3-hacking'
@@ -1508,7 +1430,13 @@ copy:
     /.*/:  # every tag
       - 'osp-rpm-py39':
           from: 'check'
+          to: 'gate'
+      - 'osp-rpm-py39':
+          from: 'check'
           to: 'weekly'
+      - 'osp-tox-pep8':
+          from: 'check'
+          to: 'gate'
       - 'osp-tox-pep8':
           from: 'check'
           to: 'weekly'

--- a/znoyder/mapper.py
+++ b/znoyder/mapper.py
@@ -99,7 +99,7 @@ def include_jobs(jobs, tag) -> list:
     jobs_to_collect = include_map.get(tag, {})
 
     for job in upstream_jobs:
-        if job.name not in jobs_to_collect:
+        if (job.name not in jobs_to_collect) or (job.pipeline != 'check'):
             LOG.warning(f'Ignoring job: {job.name} ({job.pipeline})')
             continue
 


### PR DESCRIPTION
This commit adjusts Znoyder config and mapper to include only check jobs by default. Then the new copy map entries are added to use the same jobs in gate pipeline as in check pipeline. Thanks to that we can continue work on implementing upstream-like workflow in downstream Gerrit (AKA project gating).